### PR TITLE
fix: make card links clickable on mobile

### DIFF
--- a/components/actions.tsx
+++ b/components/actions.tsx
@@ -21,20 +21,17 @@ const Actions = ({ photoUrl }: ActionsProps) => {
           width={2259}
         />
       </div>
-      <button className="absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight">
-        <div className="flex justify-center items-center">
-          <Link
-            isExternal
-            color="foreground"
-            href="https://secondself.us/"
-          >
-            <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
-              SecondSelf
-            </span>
-          </Link>
-          <GoArrowUpRight />
-        </div>
-      </button>
+      <Link
+        isExternal
+        color="foreground"
+        href="https://secondself.us/"
+        className="no-drag absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight flex justify-center items-center"
+      >
+        <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
+          SecondSelf
+        </span>
+        <GoArrowUpRight />
+      </Link>
     </div>
   );
 };

--- a/components/chatbot.tsx
+++ b/components/chatbot.tsx
@@ -21,16 +21,17 @@ const Chatbot = ({ chatbotUrl }: ChatbotProps) => {
           width={2629}
         />
       </div>
-      <button className="absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight">
-        <div className="flex justify-center items-center">
-          <Link isExternal color="foreground" href="https://beta.simplegen.ai/">
-            <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
-              AI Chatbot
-            </span>
-            <GoArrowUpRight />
-          </Link>
-        </div>
-      </button>
+      <Link
+        isExternal
+        color="foreground"
+        href="https://beta.simplegen.ai/"
+        className="no-drag absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight flex justify-center items-center"
+      >
+        <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
+          AI Chatbot
+        </span>
+        <GoArrowUpRight />
+      </Link>
     </div>
   );
 };

--- a/components/paper.tsx
+++ b/components/paper.tsx
@@ -20,20 +20,17 @@ const Paper = ({ paperUrl }: PaperProps) => {
           width={1577}
         />
       </div>
-      <button className="absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight">
-        <div className="flex justify-center items-center">
-          <Link
-            isExternal
-            color="foreground"
-            href="https://ojs.aaai.org/index.php/AAAI/article/view/29266"
-          >
-            <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
-              DT-VAEGAN
-            </span>
-            <GoArrowUpRight />
-          </Link>
-        </div>
-      </button>
+      <Link
+        isExternal
+        color="foreground"
+        href="https://ojs.aaai.org/index.php/AAAI/article/view/29266"
+        className="no-drag absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight flex justify-center items-center"
+      >
+        <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
+          DT-VAEGAN
+        </span>
+        <GoArrowUpRight />
+      </Link>
     </div>
   );
 };

--- a/components/webagent.tsx
+++ b/components/webagent.tsx
@@ -22,16 +22,17 @@ const WebAgent = ({ webAgentUrl }: WebAgentProps) => {
           width={1000}
         />
       </div>
-      <button className="absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight">
-        <div className="flex justify-center items-center">
-          <Link isExternal color="foreground" href="https://www.simplegen.ai/">
-            <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
-              Web Agent
-            </span>
-          </Link>
-          <GoArrowUpRight />
-        </div>
-      </button>
+      <Link
+        isExternal
+        color="foreground"
+        href="https://www.simplegen.ai/"
+        className="no-drag absolute bg-white dark:bg-darkBg bottom-2 left-2 transition-all w-10 h-10 md:w-[2.75rem] md:h-[2.75rem] duration-500 ease-in-out group-hover:w-40 p-2 rounded-full hover:bg-default-100 border-2 border-transparent dark:border-knight flex justify-center items-center"
+      >
+        <span className="text-sm md:text-medium text-nowrap hidden group-hover:block invisible group-hover:visible mr-1 animate-fade">
+          Web Agent
+        </span>
+        <GoArrowUpRight />
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
Replace nested button>Link structure with a single Link element so the
arrow icon is always tappable. Add no-drag class to prevent grid drag
from intercepting touch events on the link button.

https://claude.ai/code/session_01EehUnAjENF3faiEauSyCsN