### PR TITLE
Remove resume button and related data fetching

### DIFF
--- a/app/resume/page.ts
+++ b/app/resume/page.ts
@@ -1,11 +1,7 @@
 import { redirect } from "next/navigation";
 
-import { getPhotoUrl } from "@/firebase/db/photo";
-
 const Page = async () => {
-  const resumeUrl = await getPhotoUrl("Chengxiang-Wu-Resume-2024.pdf");
-
-  redirect(resumeUrl);
+  redirect("/");
 
   return null;
 };

--- a/components/dock-demo.tsx
+++ b/components/dock-demo.tsx
@@ -1,27 +1,15 @@
 import React from "react";
-import {
-  IoDocumentText,
-  IoLogoGithub,
-  IoLogoLinkedin,
-  IoMail,
-} from "react-icons/io5";
+import { IoLogoGithub, IoLogoLinkedin, IoMail } from "react-icons/io5";
 
 import { Dock, DockIcon } from "@/components/dock";
 import { siteConfig } from "@/config/site";
 
 export type IconProps = React.HTMLAttributes<SVGElement>;
 
-interface DockDemoProps {
-  resumeUrl: string;
-}
-
-export function DockDemo({ resumeUrl }: DockDemoProps) {
+export function DockDemo() {
   return (
     <button className="self-end" onMouseDown={(e) => e.stopPropagation()}>
       <Dock>
-        <DockIcon tooltip="Resume" url={resumeUrl}>
-          <IoDocumentText className="h-5 w-5" />
-        </DockIcon>
         <DockIcon tooltip="GitHub" url={siteConfig.links.github}>
           <IoLogoGithub className="h-5 w-5" />
         </DockIcon>

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -68,7 +68,6 @@ interface HomeClientProps {
   avatarUrl: string;
   dogUrl: string;
   actionImageUrl: string;
-  resumeUrl: string;
   webagentUrl: string;
   chatbotUrl: string;
   paperUrl: string;
@@ -79,7 +78,6 @@ export default function HomeClient({
   avatarUrl,
   dogUrl,
   actionImageUrl,
-  resumeUrl,
   webagentUrl,
   chatbotUrl,
   paperUrl,
@@ -152,7 +150,7 @@ export default function HomeClient({
             life easier. Outside work, I&apos;m hiking with my dog Bert and
             planning to summit Mount Rainier in 2027!
           </p>
-          <DockDemo resumeUrl={resumeUrl} />
+          <DockDemo />
         </div>
         <div
           key="themeSwitch"

--- a/components/home.tsx
+++ b/components/home.tsx
@@ -30,7 +30,6 @@ interface HomeProps {
   avatarUrl: string;
   dogUrl: string;
   actionImageUrl: string;
-  resumeUrl: string;
   webagentUrl: string;
   chatbotUrl: string;
   paperUrl: string;
@@ -41,7 +40,6 @@ const Home = ({
   avatarUrl,
   dogUrl,
   actionImageUrl,
-  resumeUrl,
   webagentUrl,
   chatbotUrl,
   paperUrl,
@@ -109,7 +107,7 @@ const Home = ({
             development, deep learning, and data science. And yes, I have an
             adorable dog named Bert!
           </p>
-          <DockDemo resumeUrl={resumeUrl} />
+          <DockDemo />
         </div>
         <div
           key="themeSwitch"

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -12,7 +12,6 @@ export const getHomeData = cache(async () => {
     action: "projects/secondself.jpg",
     webagent: "projects/webagent.jpg",
     chatbot: "projects/chatbot.jpg",
-    resume: "Chengxiang-Wu-Resume-2024.pdf",
     paper: "projects/paper.jpg",
   };
 
@@ -22,7 +21,6 @@ export const getHomeData = cache(async () => {
     paths.action,
     paths.webagent,
     paths.chatbot,
-    paths.resume,
     paths.paper,
   ];
 
@@ -41,7 +39,6 @@ export const getHomeData = cache(async () => {
     actionImageUrl: urlResults[2],
     webagentUrl: urlResults[3],
     chatbotUrl: urlResults[4],
-    resumeUrl: urlResults[5],
-    paperUrl: urlResults[6],
+    paperUrl: urlResults[5],
   };
 });


### PR DESCRIPTION
Hide resume from the website by removing the Resume dock icon,
cleaning up resumeUrl props throughout the component tree, and
redirecting /resume to the homepage.

https://claude.ai/code/session_012AZa2QFYV6QWHjaAK4UnGM